### PR TITLE
fix(codecov): Update ignore patterns in codecov.yaml

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -21,5 +21,6 @@ coverage:
 
 ignore:
   - "**/*_mock.go"
+  - "*_mock.go"
   - "**/*_test.go"
   - "**/module.go"


### PR DESCRIPTION
Added a new ignore pattern for files matching `*_mock.go`